### PR TITLE
Rename charm, add external hostname option, add initial unittest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# airflow-k8s
+# Airflow Operator
 
 ## Description
 
@@ -13,7 +13,9 @@ PostgreSQL for that purpose. One options would be to use
 [postgresql-k8s](https://charmhub.io/postgresql-k8s/), and then a relation to it:
 
 ```
-juju relate airflow-k8s:db postgresql-k8s:db
+juju deploy airflow
+juju deploy postgresql-k8s
+juju relate airflow:db postgresql-k8s:db
 ```
 
 Once the database becomes available the charm will initialise the airflow database and
@@ -29,7 +31,7 @@ The charm supports the `ingress` relation, which can be used with
 
 ```
 juju deploy nginx-ingress-integrator
-juju relate airflow-k8s:ingress nginx-ingress-integrator:ingress
+juju relate airflow:ingress nginx-ingress-integrator:ingress
 ```
 
 This charm will currently run an instance of the airflow webserver and scheduler using the

--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,7 @@ options:
   external_hostname:
     default: ""
     description: The external hostname for the web UI for airflow. Defaults to the deployed juju application name.
+    type: string
   webserver_username:
     default: airflow
     description: Username created for access to the Web UI (during db initialisation)

--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,9 @@ options:
     default: airflow
     description: Name to be used for the metadata database (during db creation)
     type: string
+  external_hostname:
+    default: ""
+    description: The external hostname for the web UI for airflow. Defaults to the deployed juju application name.
   webserver_username:
     default: airflow
     description: Username created for access to the Web UI (during db initialisation)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,7 @@
 # Copyright 2021 jguedez
 # See LICENSE file for licensing details.
-name: airflow-k8s
+name: airflow
+display-name: Airflow
 description: >
   Charm for Juju to deploy and manage Apache Airflow in a Kubernetes environment.
 summary: >

--- a/src/charm.py
+++ b/src/charm.py
@@ -50,7 +50,7 @@ class AirflowCharm(CharmBase):
 
         # ingress relation events
         self.ingress = IngressRequires(self, {
-            "service-hostname": "airflow.juju",
+            "service-hostname": self.config['external_hostname'] or self.app.name,
             "service-name": self.app.name,
             "service-port": 8080
         })
@@ -208,7 +208,10 @@ class AirflowCharm(CharmBase):
         if event.master:
             # store the data in both the peers relation and the stored bag
             conn_str = event.master
-            db_uri = f"postgresql+psycopg2://{conn_str.user}:{conn_str.password}@{conn_str.host}:{conn_str.port}/{conn_str.dbname}"
+            db_uri = (
+                f"postgresql+psycopg2://{conn_str.user}:{conn_str.password}"
+                f"@{conn_str.host}:{conn_str.port}/{conn_str.dbname}"
+            )
             self._stored.db_uri = db_uri
 
             self.unit.status = ActiveStatus()

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -4,10 +4,8 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import unittest
-from unittest.mock import Mock
 
 from charm import AirflowCharm
-from ops.model import ActiveStatus
 from ops.testing import Harness
 
 
@@ -17,50 +15,27 @@ class TestCharm(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
-    def test_config_changed(self):
-        self.assertEqual(list(self.harness.charm._stored.things), [])
-        self.harness.update_config({"thing": "foo"})
-        self.assertEqual(list(self.harness.charm._stored.things), ["foo"])
-
-    def test_action(self):
-        # the harness doesn't (yet!) help much with actions themselves
-        action_event = Mock(params={"fail": ""})
-        self.harness.charm._on_fortune_action(action_event)
-
-        self.assertTrue(action_event.set_results.called)
-
-    def test_action_fail(self):
-        action_event = Mock(params={"fail": "fail this"})
-        self.harness.charm._on_fortune_action(action_event)
-
-        self.assertEqual(action_event.fail.call_args, [("fail this",)])
-
-    def test_httpbin_pebble_ready(self):
-        # Check the initial Pebble plan is empty
-        initial_plan = self.harness.get_container_pebble_plan("httpbin")
-        self.assertEqual(initial_plan.to_yaml(), "{}\n")
-        # Expected plan after Pebble ready with default config
-        expected_plan = {
+    def test_get_common_airflow_layer(self):
+        expected = {
+            "summary": "test-container layer",
+            "description": "pebble config layer for test-container",
             "services": {
-                "httpbin": {
+                "test-container": {
                     "override": "replace",
-                    "summary": "httpbin",
-                    "command": "gunicorn -b 0.0.0.0:80 httpbin:app -k gevent",
+                    "summary": "test-container",
+                    "command": "/entrypoint test-command",
                     "startup": "enabled",
-                    "environment": {"thing": "🎁"},
+                    "environment": {
+                        "AIRFLOW__CORE__EXECUTOR": "LocalExecutor",
+                        "AIRFLOW__CORE__FERNET_KEY": "",
+                        "AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION": "true",
+                        "AIRFLOW__CORE__LOAD_EXAMPLES": "true",
+                        "AIRFLOW__API__AUTH_BACKEND": "airflow.api.auth.backend.basic_auth",
+                    },
                 }
             },
         }
-        # Get the httpbin container from the model
-        container = self.harness.model.unit.get_container("httpbin")
-        # Emit the PebbleReadyEvent carrying the httpbin container
-        self.harness.charm.on.httpbin_pebble_ready.emit(container)
-        # Get the plan now we've run PebbleReady
-        updated_plan = self.harness.get_container_pebble_plan("httpbin").to_dict()
-        # Check we've got the plan we expected
-        self.assertEqual(expected_plan, updated_plan)
-        # Check the service was started
-        service = self.harness.model.unit.get_container("httpbin").get_service("httpbin")
-        self.assertTrue(service.is_running())
-        # Ensure we set an ActiveStatus with no message
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
+        self.assertEqual(
+            self.harness.charm._get_common_airflow_layer("test-container", "test-command"),
+            expected,
+        )


### PR DESCRIPTION
This PR does a few things:

- Renames charm to airflow since there's no machine version of the charm already. This was something that was recommended for other charms during the sidecar charming exercise. This will mean it ends up needing to be published in charmhub under the new name.
- Adds an external hostname config option but defaults to deployed application name per recommendations received on other charms as part of the sidecar charming exercise.
- Adds an initial unit test and fixes lint checks.